### PR TITLE
fix path for kubeconfig

### DIFF
--- a/pkg/cmd/cluster-policy-controller/cmd.go
+++ b/pkg/cmd/cluster-policy-controller/cmd.go
@@ -125,7 +125,7 @@ func (o *ClusterPolicyController) RunPolicyController() error {
 
 	setRecommendedOpenShiftControllerConfigDefaults(config)
 
-	clientConfig, err := helpers.GetKubeConfigOrInClusterConfig(o.ConfigFilePath, config.KubeClientConfig.ConnectionOverrides)
+	clientConfig, err := helpers.GetKubeConfigOrInClusterConfig(config.KubeClientConfig.KubeConfig, config.KubeClientConfig.ConnectionOverrides)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This isn't yet used  in a paylod, but we need this to unstick our operator.

I will abuse my power to get an image for CI faster.