### PR TITLE
Bug 1794366: Fix GOFLAGS in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-policy-controller
 RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
-RUN make build --warn-undefined-variables
+RUN GOFLAGS="" make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-policy-controller/cluster-policy-controller /usr/bin/

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-policy-controller
 RUN yum install -y gpgme-devel libassuan-devel
 COPY . .
-RUN make build --warn-undefined-variables
+RUN GOFLAGS="" make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/cluster-policy-controller/cluster-policy-controller /usr/bin/


### PR DESCRIPTION
This unblocks CI job that is failing because cluster-policy-controller binary is not present in payload image.

This should be reverted and handled properly later.