### PR TITLE
the quota controllers should resync on new resources and make progress

### DIFF
--- a/pkg/quota/clusterquotareconciliation/reconciliation_controller.go
+++ b/pkg/quota/clusterquotareconciliation/reconciliation_controller.go
@@ -205,11 +205,11 @@ func (c *ClusterQuotaReconcilationController) Sync(discoveryFunc resourcequota.N
 // resyncMonitors starts or stops quota monitors as needed to ensure that all
 // (and only) those resources present in the map are monitored.
 func (c *ClusterQuotaReconcilationController) resyncMonitors(resources map[schema.GroupVersionResource]struct{}) error {
-	if err := c.quotaMonitor.SyncMonitors(resources); err != nil {
-		return err
-	}
+	// SyncMonitors can only fail if there was no Informer for the given gvr
+	err := c.quotaMonitor.SyncMonitors(resources)
+	// this is no-op for already running monitors
 	c.quotaMonitor.StartMonitors()
-	return nil
+	return err
 }
 
 func (c *ClusterQuotaReconcilationController) calculate(quotaName string, namespaceNames ...string) {
@@ -264,14 +264,14 @@ func (c *ClusterQuotaReconcilationController) calculateAll() {
 // It enforces that the syncHandler is never invoked concurrently with the same key.
 func (c *ClusterQuotaReconcilationController) worker() {
 	workFunc := func() bool {
-		c.workerLock.RLock()
-		defer c.workerLock.RUnlock()
-
 		uncastKey, uncastData, quit := c.queue.GetWithData()
 		if quit {
 			return true
 		}
 		defer c.queue.Done(uncastKey)
+
+		c.workerLock.RLock()
+		defer c.workerLock.RUnlock()
 
 		quotaName := uncastKey.(string)
 		quota, err := c.clusterQuotaLister.Get(quotaName)


### PR DESCRIPTION
this PR fixes the following (potential) issues:

1. both controllers should periodically resync when new resources are observed from discovery.
2. the CRQ should always ensure the current set of monitors are running.
3. CRQ should not block when new resources are observed.