### PR TITLE
CSR: fix the subject for monitoring CSRs approval

### DIFF
--- a/pkg/cmd/controller/csr.go
+++ b/pkg/cmd/controller/csr.go
@@ -12,7 +12,7 @@ const (
 	controllerName                    = "csr-approver-controller"
 	monitoringServiceAccountNamespace = "openshift-monitoring"
 	monitoringServiceAccountName      = "cluster-monitoring-operator"
-	monitoringCertificateSubject      = "/CN=system:serviceaccount:openshift-monitoring:prometheus-k8s"
+	monitoringCertificateSubject      = "CN=system:serviceaccount:openshift-monitoring:prometheus-k8s"
 	monitoringLabelKey                = "metrics.openshift.io/csr.subject"
 	monitoringLabelValue              = "prometheus"
 )


### PR DESCRIPTION
Looks like the CSRs actually don't prepend the CN with a slash.

/assign @slaskawi 