### PR TITLE
add namespace SCC allocation metrics

### DIFF
--- a/pkg/cmd/controller/security.go
+++ b/pkg/cmd/controller/security.go
@@ -28,7 +28,6 @@ func RunNamespaceSecurityAllocationController(ctx context.Context, controllerCtx
 	if err != nil {
 		return true, err
 	}
-
 	controller := sccallocation.NewNamespaceSCCAllocationController(
 		controllerCtx.KubernetesInformers.Core().V1().Namespaces(),
 		kubeClient.CoreV1().Namespaces(),

--- a/pkg/security/controller/repair_test.go
+++ b/pkg/security/controller/repair_test.go
@@ -33,6 +33,7 @@ func TestRepair(t *testing.T) {
 		requiredUIDRange:      uidr,
 		nsLister:              corev1listers.NewNamespaceLister(indexer),
 		rangeAllocationClient: securityclient.SecurityV1(),
+		metrics:               newFakeNamespaceSCCAllocMetrics(),
 	}
 
 	syncContext := factory.NewSyncContext(controllerName, events.NewInMemoryRecorder(controllerName))
@@ -76,6 +77,7 @@ func TestRepairIgnoresMismatch(t *testing.T) {
 		requiredUIDRange:      uidr,
 		nsLister:              corev1listers.NewNamespaceLister(indexer),
 		rangeAllocationClient: securityclient.SecurityV1(),
+		metrics:               newFakeNamespaceSCCAllocMetrics(),
 	}
 
 	syncContext := factory.NewSyncContext(controllerName, events.NewInMemoryRecorder(controllerName))
@@ -168,6 +170,7 @@ func TestRepairTable(t *testing.T) {
 				requiredUIDRange:      uidr,
 				nsLister:              corev1listers.NewNamespaceLister(indexer),
 				rangeAllocationClient: securityclient.SecurityV1(),
+				metrics:               newFakeNamespaceSCCAllocMetrics(),
 			}
 
 			syncContext := factory.NewSyncContext(controllerName, events.NewInMemoryRecorder(controllerName))

--- a/pkg/security/controller/utils.go
+++ b/pkg/security/controller/utils.go
@@ -2,7 +2,10 @@ package controller
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
+
+	v1 "github.com/openshift/api/securityinternal/v1"
 )
 
 const (
@@ -20,4 +23,50 @@ func parseNamespaceNameKey(key string) (namespace string, err error) {
 	}
 
 	return parts[1], nil
+}
+
+type fakeNamespaceSCCAllocMetrics struct {
+	uidRanges           []v1.RangeAllocation
+	namespacesProcessed []int
+}
+
+func newFakeNamespaceSCCAllocMetrics() *fakeNamespaceSCCAllocMetrics {
+	return &fakeNamespaceSCCAllocMetrics{}
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) SetNamespacesProcessed(count int) {
+	r.namespacesProcessed = append(r.namespacesProcessed, count)
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) AddNamespacesProcessed(delta int) {
+	last := 0
+	if len(r.namespacesProcessed) > 0 {
+		last = r.namespacesProcessed[0]
+	}
+	r.namespacesProcessed = append(r.namespacesProcessed, last+delta)
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) UIDRangeUpdated(uidRange *v1.RangeAllocation) {
+	r.uidRanges = append(r.uidRanges, *uidRange)
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) getLatestNamespaceProcessed() int {
+	if len(r.namespacesProcessed) == 0 {
+		return -1
+	}
+	return r.namespacesProcessed[len(r.namespacesProcessed)-1]
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) getLatestUidRange() v1.RangeAllocation {
+	if len(r.uidRanges) == 0 {
+		return v1.RangeAllocation{}
+	}
+	return r.uidRanges[len(r.uidRanges)-1]
+}
+
+func (r *fakeNamespaceSCCAllocMetrics) getLatestAllocatedUid() uint64 {
+	latestRange := r.getLatestUidRange()
+
+	actualAllocatedInt := big.NewInt(0).SetBytes(latestRange.Data)
+	return actualAllocatedInt.Uint64()
 }

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"github.com/openshift/library-go/pkg/security/uid"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"math/big"
+	"math/bits"
+	"sync"
+
+	v1 "github.com/openshift/api/securityinternal/v1"
+)
+
+const (
+	namespaceSCCAllocSubsystem = "openshift_namespace_scc_allocation"
+
+	namespaceProcessedCountKey = "namespace_processed_total"
+	uidBlocksCountKey          = "uid_blocks_total"
+	uidBlocksAllocatedCountKey = "uid_blocks_allocated_total"
+)
+
+var (
+	namespacesProcessedCount = metrics.NewGauge(&metrics.GaugeOpts{
+		Subsystem:      namespaceSCCAllocSubsystem,
+		Name:           namespaceProcessedCountKey,
+		Help:           "Number of namespaces that have assigned Security Context Constraints (SCC) annotations",
+		StabilityLevel: metrics.ALPHA,
+	})
+	uidBlocksCount = metrics.NewGauge(&metrics.GaugeOpts{
+		Subsystem:      namespaceSCCAllocSubsystem,
+		Name:           uidBlocksCountKey,
+		Help:           "Total number of UID blocks for allocation.",
+		StabilityLevel: metrics.ALPHA,
+	})
+	uidBlocksAllocatedCount = metrics.NewGauge(&metrics.GaugeOpts{
+		Subsystem:      namespaceSCCAllocSubsystem,
+		Name:           uidBlocksAllocatedCountKey,
+		Help:           "Allocated number of UID blocks.",
+		StabilityLevel: metrics.ALPHA,
+	})
+)
+
+var registerMetrics sync.Once
+
+// Register registers NamespaceSCCAllocation metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(namespacesProcessedCount)
+		legacyregistry.MustRegister(uidBlocksCount)
+		legacyregistry.MustRegister(uidBlocksAllocatedCount)
+	})
+}
+
+type NamespaceSCCAllocationMetrics interface {
+	UIDRangeUpdated(uidRange *v1.RangeAllocation)
+	SetNamespacesProcessed(count int)
+	AddNamespacesProcessed(delta int)
+}
+
+type namespaceSCCAllocMetrics struct {
+}
+
+// NewNamespaceSCCAllocMetrics creates a NamespaceSCCAllocationMetrics
+func NewNamespaceSCCAllocMetrics() NamespaceSCCAllocationMetrics {
+	return &namespaceSCCAllocMetrics{}
+}
+
+func (r *namespaceSCCAllocMetrics) SetNamespacesProcessed(count int) {
+	namespacesProcessedCount.Set(float64(count))
+}
+
+func (r *namespaceSCCAllocMetrics) AddNamespacesProcessed(delta int) {
+	namespacesProcessedCount.Add(float64(delta))
+}
+
+func (r *namespaceSCCAllocMetrics) UIDRangeUpdated(uidRange *v1.RangeAllocation) {
+	blocksCount := -1.0
+	uRange, err := uid.ParseRange(uidRange.Range)
+	if err == nil {
+		blocksCount = float64(uRange.Size())
+	}
+	uidBlocksCount.Set(blocksCount)
+
+	allocatedBitMapInt := big.NewInt(0).SetBytes(uidRange.Data)
+	uidBlocksAllocated := float64(countBits(allocatedBitMapInt))
+	uidBlocksAllocatedCount.Set(uidBlocksAllocated)
+}
+
+// countBits returns the number of set bits in n
+func countBits(n *big.Int) int {
+	count := 0
+	for _, b := range n.Bytes() {
+		count += bits.OnesCount8(b)
+	}
+	return count
+}


### PR DESCRIPTION
this will add a `openshift_namespace_scc_allocation_total` metric. This metric tracks `Resolved`/`Pending` namespaces that have resolved scc annotations. This would help for example with bugs like these: https://bugzilla.redhat.com/show_bug.cgi?id=1968383

TODO:
- [x] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/554
- [x] https://github.com/openshift/installer/pull/5105
- [ ] https://github.com/openshift/cluster-kube-controller-manager-operator/pull/615