### PR TITLE
Revert "psalabelsyncer: synchronize the enforcement label"

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -284,29 +284,19 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) syncNamespace(ctx c
 	nsCopy := ns.DeepCopy()
 
 	var changed bool
-	if nsCopy.Labels[psapi.EnforceLevelLabel] != string(psaLevel) || nsCopy.Labels[psapi.EnforceVersionLabel] != currentPSaVersion {
-		changed = true
-		if nsCopy.Labels == nil {
-			nsCopy.Labels = map[string]string{}
-		}
-
-		nsCopy.Labels[psapi.EnforceLevelLabel] = string(psaLevel)
-		nsCopy.Labels[psapi.EnforceVersionLabel] = currentPSaVersion
-	}
-
-	// cleanup audit and warn labels from version 4.11
-	// TODO: This can be removed in 4.13 and allow users set these as they wish
 	for typeLabel, versionLabel := range map[string]string{
 		psapi.WarnLevelLabel:  psapi.WarnVersionLabel,
 		psapi.AuditLevelLabel: psapi.AuditVersionLabel,
 	} {
-		if _, ok := nsCopy.Labels[typeLabel]; ok {
-			delete(nsCopy.Labels, typeLabel)
+		if ns.Labels[typeLabel] != string(psaLevel) || ns.Labels[versionLabel] != currentPSaVersion {
 			changed = true
-		}
-		if _, ok := nsCopy.Labels[versionLabel]; ok {
-			delete(nsCopy.Labels, versionLabel)
-			changed = true
+			if nsCopy.Labels == nil {
+				nsCopy.Labels = map[string]string{}
+			}
+
+			nsCopy.Labels[typeLabel] = string(psaLevel)
+			nsCopy.Labels[versionLabel] = currentPSaVersion
+
 		}
 	}
 


### PR DESCRIPTION
This reverts commit f42d97302cb29ef170257d98f01824b4276c2bb5.

Looks like ovn tests got broken, fix is in https://github.com/openshift/origin/pull/27325