### PR TITLE
Revert "psalabelsyncer: synchronize the enforcement label"

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -284,29 +284,19 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) syncNamespace(ctx c
 	nsCopy := ns.DeepCopy()
 
 	var changed bool
-	if nsCopy.Labels[psapi.EnforceLevelLabel] != string(psaLevel) || nsCopy.Labels[psapi.EnforceVersionLabel] != currentPSaVersion {
-		changed = true
-		if nsCopy.Labels == nil {
-			nsCopy.Labels = map[string]string{}
-		}
-
-		nsCopy.Labels[psapi.EnforceLevelLabel] = string(psaLevel)
-		nsCopy.Labels[psapi.EnforceVersionLabel] = currentPSaVersion
-	}
-
-	// cleanup audit and warn labels from version 4.11
-	// TODO: This can be removed in 4.13 and allow users set these as they wish
 	for typeLabel, versionLabel := range map[string]string{
 		psapi.WarnLevelLabel:  psapi.WarnVersionLabel,
 		psapi.AuditLevelLabel: psapi.AuditVersionLabel,
 	} {
-		if _, ok := nsCopy.Labels[typeLabel]; ok {
-			delete(nsCopy.Labels, typeLabel)
+		if ns.Labels[typeLabel] != string(psaLevel) || ns.Labels[versionLabel] != currentPSaVersion {
 			changed = true
-		}
-		if _, ok := nsCopy.Labels[versionLabel]; ok {
-			delete(nsCopy.Labels, versionLabel)
-			changed = true
+			if nsCopy.Labels == nil {
+				nsCopy.Labels = map[string]string{}
+			}
+
+			nsCopy.Labels[typeLabel] = string(psaLevel)
+			nsCopy.Labels[versionLabel] = currentPSaVersion
+
 		}
 	}
 


### PR DESCRIPTION
This reverts commit f42d97302cb29ef170257d98f01824b4276c2bb5.

Per [TRT policy](https://github.com/openshift/enhancements/blob/725a118640d7b9fa8c6f720f2adb841de654fac5/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

This test appears to have broken all CI and nightly payloads due to ovn tests that look to violate the policy being enforced now. See https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-aws-ovn-upgrade/1552466101101662208 for an example.

Understandably this is likely not a problem with this PR per se, rather the pre-existing test, however we are requested to revert as quickly as possible to restore the orgs ability to ship code which is currently blocked, so this is the change that needs a revert.

To bring this back in you will likely need to coordinate with the network team to get their test fixed, and then "unrevert this revert", open a new PR, and run "/payload 4.12 ci blocking", this will prove the issue is now addressed. This was able to slip in because the upgrade job on this pr is not using OVN. However that default is about to change and likely your upgrade job will flip to ovn by default, so no real change needed there.


CC: @stlaz @deads2k 

