### PR TITLE
Factor our ns exemptions to make them consumable by other components

### DIFF
--- a/pkg/psalabelsyncer/nsexemptions/nsexemptions.go
+++ b/pkg/psalabelsyncer/nsexemptions/nsexemptions.go
@@ -1,0 +1,85 @@
+package nsexemptions
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// systemNSSyncExemptions is the list of namespaces deployed by an OpenShift install
+// payload, as retrieved by listing the namespaces after a successful installation
+// IMPORTANT: The Namespace openshift-operators must be an exception to this rule
+// since it is used by OCP/OLM users to install their Operator bundle solutions.
+var systemNSSyncExemptions = sets.NewString(
+	// kube-specific system namespaces
+	"default",
+	"kube-node-lease",
+	"kube-public",
+	"kube-system",
+
+	// openshift payload namespaces
+	"openshift",
+	"openshift-apiserver",
+	"openshift-apiserver-operator",
+	"openshift-authentication",
+	"openshift-authentication-operator",
+	"openshift-cloud-controller-manager",
+	"openshift-cloud-controller-manager-operator",
+	"openshift-cloud-credential-operator",
+	"openshift-cloud-network-config-controller",
+	"openshift-cluster-csi-drivers",
+	"openshift-cluster-machine-approver",
+	"openshift-cluster-node-tuning-operator",
+	"openshift-cluster-samples-operator",
+	"openshift-cluster-storage-operator",
+	"openshift-cluster-version",
+	"openshift-config",
+	"openshift-config-managed",
+	"openshift-config-operator",
+	"openshift-console",
+	"openshift-console-operator",
+	"openshift-console-user-settings",
+	"openshift-controller-manager",
+	"openshift-controller-manager-operator",
+	"openshift-dns",
+	"openshift-dns-operator",
+	"openshift-etcd",
+	"openshift-etcd-operator",
+	"openshift-host-network",
+	"openshift-image-registry",
+	"openshift-infra",
+	"openshift-ingress",
+	"openshift-ingress-canary",
+	"openshift-ingress-operator",
+	"openshift-insights",
+	"openshift-kni-infra",
+	"openshift-kube-apiserver",
+	"openshift-kube-apiserver-operator",
+	"openshift-kube-controller-manager",
+	"openshift-kube-controller-manager-operator",
+	"openshift-kube-scheduler",
+	"openshift-kube-scheduler-operator",
+	"openshift-kube-storage-version-migrator",
+	"openshift-kube-storage-version-migrator-operator",
+	"openshift-machine-api",
+	"openshift-machine-config-operator",
+	"openshift-marketplace",
+	"openshift-monitoring",
+	"openshift-multus",
+	"openshift-network-diagnostics",
+	"openshift-network-operator",
+	"openshift-node",
+	"openshift-nutanix-infra",
+	"openshift-oauth-apiserver",
+	"openshift-openstack-infra",
+	"openshift-operator-lifecycle-manager",
+	"openshift-ovirt-infra",
+	"openshift-sdn",
+	"openshift-service-ca",
+	"openshift-service-ca-operator",
+	"openshift-user-workload-monitoring",
+	"openshift-vsphere-infra",
+)
+
+// IsNamespacePSALabelSyncExemptedInVendoredOCPVersion returns true if the given namespace should be exempted from
+// PSA label sync'ing. NOTE: the exemption list is OCP version dependent. Ensure that your vendored
+// version of 'cluster-policy-controller' is for the same OCP version as your project.
+func IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(namespace string) bool {
+	return systemNSSyncExemptions.Has(namespace)
+}

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer/nsexemptions"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,81 +34,6 @@ const (
 	controllerName        = "pod-security-admission-label-synchronization-controller"
 	labelSyncControlLabel = "security.openshift.io/scc.podSecurityLabelSync"
 	currentPSaVersion     = "v1.24"
-)
-
-// systemNSSyncExemptions is the list of namespaces deployed by an OpenShift install
-// payload, as retrieved by listing the namespaces after a successful installation
-// IMPORTANT: The Namespace openshift-operators must be an exception to this rule
-// since it is used by OCP/OLM users to install their Operator bundle solutions.
-var systemNSSyncExemptions = sets.NewString(
-	// kube-specific system namespaces
-	"default",
-	"kube-node-lease",
-	"kube-public",
-	"kube-system",
-
-	// openshift payload namespaces
-	"openshift",
-	"openshift-apiserver",
-	"openshift-apiserver-operator",
-	"openshift-authentication",
-	"openshift-authentication-operator",
-	"openshift-cloud-controller-manager",
-	"openshift-cloud-controller-manager-operator",
-	"openshift-cloud-credential-operator",
-	"openshift-cloud-network-config-controller",
-	"openshift-cluster-csi-drivers",
-	"openshift-cluster-machine-approver",
-	"openshift-cluster-node-tuning-operator",
-	"openshift-cluster-samples-operator",
-	"openshift-cluster-storage-operator",
-	"openshift-cluster-version",
-	"openshift-config",
-	"openshift-config-managed",
-	"openshift-config-operator",
-	"openshift-console",
-	"openshift-console-operator",
-	"openshift-console-user-settings",
-	"openshift-controller-manager",
-	"openshift-controller-manager-operator",
-	"openshift-dns",
-	"openshift-dns-operator",
-	"openshift-etcd",
-	"openshift-etcd-operator",
-	"openshift-host-network",
-	"openshift-image-registry",
-	"openshift-infra",
-	"openshift-ingress",
-	"openshift-ingress-canary",
-	"openshift-ingress-operator",
-	"openshift-insights",
-	"openshift-kni-infra",
-	"openshift-kube-apiserver",
-	"openshift-kube-apiserver-operator",
-	"openshift-kube-controller-manager",
-	"openshift-kube-controller-manager-operator",
-	"openshift-kube-scheduler",
-	"openshift-kube-scheduler-operator",
-	"openshift-kube-storage-version-migrator",
-	"openshift-kube-storage-version-migrator-operator",
-	"openshift-machine-api",
-	"openshift-machine-config-operator",
-	"openshift-marketplace",
-	"openshift-monitoring",
-	"openshift-multus",
-	"openshift-network-diagnostics",
-	"openshift-network-operator",
-	"openshift-node",
-	"openshift-nutanix-infra",
-	"openshift-oauth-apiserver",
-	"openshift-openstack-infra",
-	"openshift-operator-lifecycle-manager",
-	"openshift-ovirt-infra",
-	"openshift-sdn",
-	"openshift-service-ca",
-	"openshift-service-ca-operator",
-	"openshift-user-workload-monitoring",
-	"openshift-vsphere-infra",
 )
 
 // PodSecurityAdmissionLabelSynchronizationController watches over namespaces labelled with
@@ -400,7 +326,9 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) isNSControlled(nsNa
 
 func isNSControlled(ns *corev1.Namespace) bool {
 	nsName := ns.Name
-	if systemNSSyncExemptions.Has(nsName) {
+
+	// never sync exempted namespaces
+	if nsexemptions.IsNamespacePSALabelSyncExemptedInVendoredOCPVersion(nsName) {
 		return false
 	}
 


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

#### Description
Factors out list of exempt namespaces into its own package, which surfaces a function to check whether a namespace is exempt from sync'ing or not

#### Motivation
The OLM team is creating a process to enable sync'ing on non-payload openshift-* namespaces that contain operators (ClusterServiceVersion resource). It will also ignore exempt namespaces. This change makes it so that the OLM team's process can draw a dependency on the label syncer and user it as a single source of truth for the exemption list.

#### Alternatives
Instead of moving the list to its own package, we could just surface the function from within the `psalabelsyncer` package itself. I felt putting it in its own package was better as it hides the implementation and keeps the list safe from orthogonal changes (insertions, deletions, etc.).