### PR TITLE
pkg/psalabelsyncer: rm unused, simple bool return

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -412,11 +412,7 @@ func isNSControlled(ns *corev1.Namespace) bool {
 		return ns.Labels[labelSyncControlLabel] == "true"
 	}
 
-	if ns.Labels[labelSyncControlLabel] != "false" {
-		return true
-	}
-
-	return false
+	return ns.Labels[labelSyncControlLabel] != "false"
 }
 
 // controlledNamespacesLabelSelector returns label selector to be used with the

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
@@ -206,7 +206,7 @@ func TestPodSecurityAdmissionLabelSynchronizationController_saToSCCCAcheEnqueueF
 
 	for _, ns := range testNamespaces {
 		ns := ns
-		namespaces.Add(ns)
+		require.NoError(t, namespaces.Add(ns))
 	}
 	nsLister := corev1listers.NewNamespaceLister(namespaces)
 	labelSelector, err := controlledNamespacesLabelSelector()
@@ -270,11 +270,6 @@ func TestPodSecurityAdmissionLabelSynchronizationController_saToSCCCAcheEnqueueF
 }
 
 func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
-	type args struct {
-		ctx               context.Context
-		controllerContext factory.SyncContext
-	}
-
 	labelSelector, err := controlledNamespacesLabelSelector()
 	require.NoError(t, err)
 
@@ -366,7 +361,7 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 			expectedPSaLevel: "restricted",
 		},
 		{
-			name:   "SA with restricted SCC assigned in am NS with previous enforce labels",
+			name:   "SA with restricted SCC assigned in an NS with previous enforce labels",
 			nsName: "controlled-namespace-previous-enforce-labels",
 			serviceAccounts: []*corev1.ServiceAccount{
 				{ObjectMeta: metav1.ObjectMeta{Name: "testspecificsa3", Namespace: "controlled-namespace-previous-enforce-labels"}},
@@ -376,7 +371,7 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 			expectedPSaLevel: "restricted",
 		},
 		{
-			name:   "SA with restricted SCC assigned in am NS with previous warn labels",
+			name:   "SA with restricted SCC assigned in an NS with previous warn labels",
 			nsName: "controlled-namespace-previous-warn-labels",
 			serviceAccounts: []*corev1.ServiceAccount{
 				{ObjectMeta: metav1.ObjectMeta{Name: "testspecificsa3", Namespace: "controlled-namespace-previous-warn-labels"}},

--- a/pkg/psalabelsyncer/sccrolecache_test.go
+++ b/pkg/psalabelsyncer/sccrolecache_test.go
@@ -364,23 +364,6 @@ func TestSCCRoleCache_SCCsFor(t *testing.T) {
 }
 
 func Test_saToSCCCache_getRoleFromRoleRef(t *testing.T) {
-	type fields struct {
-		roleLister                rbacv1listers.RoleLister
-		clusterRoleLister         rbacv1listers.ClusterRoleLister
-		roleBindingIndexer        cache.Indexer
-		clusterRoleBindingIndexer cache.Indexer
-		sccLister                 securityv1listers.SecurityContextConstraintsLister
-		rolesSynced               cache.InformerSynced
-		roleBindingsSynced        cache.InformerSynced
-		usefulRolesLock           sync.Mutex
-		usefulRoles               map[string][]string
-		externalQueueEnqueueFunc  func(interface{})
-	}
-	type args struct {
-		ns      string
-		roleRef rbacv1.RoleRef
-	}
-
 	roleRef := func(name string) rbacv1.RoleRef {
 		return rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
@@ -784,8 +767,6 @@ func Test_saToSCCCache_handleRoleModified(t *testing.T) {
 			switch o := obj.(type) {
 			case metav1.ObjectMetaAccessor:
 				itemAdded = o.GetObjectMeta().GetNamespace()
-			case RoleInterface:
-				itemAdded = o.Namespace()
 			default:
 				t.Errorf("what is this? %T", obj)
 			}
@@ -890,8 +871,6 @@ func Test_saToSCCCache_handleRoleRemoved(t *testing.T) {
 				switch o := obj.(type) {
 				case metav1.ObjectMetaAccessor:
 					itemAdded = o.GetObjectMeta().GetNamespace()
-				case RoleInterface:
-					itemAdded = o.Namespace()
 				default:
 					t.Errorf("what is this? %T", obj)
 				}
@@ -998,8 +977,6 @@ func Test_saToSCCCache_handleSCCDeleted(t *testing.T) {
 				switch o := obj.(type) {
 				case metav1.ObjectMetaAccessor:
 					itemAdded = o.GetObjectMeta().GetNamespace()
-				case RoleInterface:
-					itemAdded = o.Namespace()
 				default:
 					t.Errorf("what is this? %T", obj)
 				}


### PR DESCRIPTION
# What

- remove unused code from tests
- some spell errors
- more simple bool return

# Why

Ran a linter, after running into complicated bool return.

# Who

@stlaz, @s-urbaniak 

Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>