### PR TITLE
OCPBUGS-3985: enforce pod security admission when techpreview is enabled

### DIFF
--- a/pkg/cmd/controller/psalabelsyncer.go
+++ b/pkg/cmd/controller/psalabelsyncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/openshift/cluster-policy-controller/pkg/psalabelsyncer"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func runPodSecurityAdmissionLabelSynchronizationController(ctx context.Context, controllerCtx *EnhancedControllerContext) (bool, error) {
@@ -13,19 +14,40 @@ func runPodSecurityAdmissionLabelSynchronizationController(ctx context.Context, 
 		return true, err
 	}
 
-	controller, err := psalabelsyncer.NewPodSecurityAdmissionLabelSynchronizationController(
-		kubeClient.CoreV1().Namespaces(),
-		controllerCtx.KubernetesInformers.Core().V1().Namespaces(),
-		controllerCtx.KubernetesInformers.Rbac().V1(),
-		controllerCtx.KubernetesInformers.Core().V1().ServiceAccounts(),
-		controllerCtx.SecurityInformers.Security().V1().SecurityContextConstraints(),
-		controllerCtx.EventRecorder.ForComponent("podsecurity-admission-label-sync-controller"),
-	)
+	featureGates := sets.NewString(controllerCtx.OpenshiftControllerConfig.FeatureGates...)
+	switch {
+	case featureGates.Has("OpenShiftPodSecurityAdmission=false"):
+		// if explicitly off, disable
+		controller, err := psalabelsyncer.NewAdvisingPodSecurityAdmissionLabelSynchronizationController(
+			kubeClient.CoreV1().Namespaces(),
+			controllerCtx.KubernetesInformers.Core().V1().Namespaces(),
+			controllerCtx.KubernetesInformers.Rbac().V1(),
+			controllerCtx.KubernetesInformers.Core().V1().ServiceAccounts(),
+			controllerCtx.SecurityInformers.Security().V1().SecurityContextConstraints(),
+			controllerCtx.EventRecorder.ForComponent("podsecurity-admission-label-sync-controller"),
+		)
+		if err != nil {
+			return true, err
+		}
+		go controller.Run(ctx, 1)
 
-	if err != nil {
-		return true, err
+	case featureGates.Has("OpenShiftPodSecurityAdmission=true"):
+		// if explicitly on or unspecified, run as enforcing.
+		fallthrough
+	default:
+		controller, err := psalabelsyncer.NewEnforcingPodSecurityAdmissionLabelSynchronizationController(
+			kubeClient.CoreV1().Namespaces(),
+			controllerCtx.KubernetesInformers.Core().V1().Namespaces(),
+			controllerCtx.KubernetesInformers.Rbac().V1(),
+			controllerCtx.KubernetesInformers.Core().V1().ServiceAccounts(),
+			controllerCtx.SecurityInformers.Security().V1().SecurityContextConstraints(),
+			controllerCtx.EventRecorder.ForComponent("podsecurity-admission-label-sync-controller"),
+		)
+		if err != nil {
+			return true, err
+		}
+		go controller.Run(ctx, 1)
 	}
 
-	go controller.Run(ctx, 1)
 	return true, nil
 }

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -210,29 +210,19 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) syncNamespace(ctx c
 	nsCopy := ns.DeepCopy()
 
 	var changed bool
-	if nsCopy.Labels[psapi.EnforceLevelLabel] != string(psaLevel) || nsCopy.Labels[psapi.EnforceVersionLabel] != currentPSaVersion {
-		changed = true
-		if nsCopy.Labels == nil {
-			nsCopy.Labels = map[string]string{}
-		}
-
-		nsCopy.Labels[psapi.EnforceLevelLabel] = string(psaLevel)
-		nsCopy.Labels[psapi.EnforceVersionLabel] = currentPSaVersion
-	}
-
-	// cleanup audit and warn labels from version 4.11
-	// TODO: This can be removed in 4.13 and allow users set these as they wish
 	for typeLabel, versionLabel := range map[string]string{
 		psapi.WarnLevelLabel:  psapi.WarnVersionLabel,
 		psapi.AuditLevelLabel: psapi.AuditVersionLabel,
 	} {
-		if _, ok := nsCopy.Labels[typeLabel]; ok {
-			delete(nsCopy.Labels, typeLabel)
+		if ns.Labels[typeLabel] != string(psaLevel) || ns.Labels[versionLabel] != currentPSaVersion {
 			changed = true
-		}
-		if _, ok := nsCopy.Labels[versionLabel]; ok {
-			delete(nsCopy.Labels, versionLabel)
-			changed = true
+			if nsCopy.Labels == nil {
+				nsCopy.Labels = map[string]string{}
+			}
+
+			nsCopy.Labels[typeLabel] = string(psaLevel)
+			nsCopy.Labels[versionLabel] = currentPSaVersion
+
 		}
 	}
 

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
@@ -34,8 +34,6 @@ var (
 		{ObjectMeta: metav1.ObjectMeta{Name: "controlled-namespace-too", Annotations: map[string]string{securityv1.UIDRangeAnnotation: "1000/1050"}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "controlled-namespace-terminating", Annotations: map[string]string{securityv1.UIDRangeAnnotation: "1000/1052"}}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "controlled-namespace-without-uid-annotation"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "controlled-namespace-previous-enforce-labels", Annotations: map[string]string{securityv1.UIDRangeAnnotation: "1000/1052"}, Labels: map[string]string{psapi.EnforceLevelLabel: "bogus value", psapi.EnforceVersionLabel: "bogus version value"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "controlled-namespace-previous-warn-labels", Annotations: map[string]string{securityv1.UIDRangeAnnotation: "1000/1052"}, Labels: map[string]string{psapi.WarnLevelLabel: "bogus value", psapi.WarnVersionLabel: "bogus version value"}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "non-controlled-namespace", Labels: map[string]string{"security.openshift.io/scc.podSecurityLabelSync": "false"}, Annotations: map[string]string{securityv1.UIDRangeAnnotation: "1000/1052"}}},
 	}
 )
@@ -285,11 +283,9 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 
 	mockCache := &mockSAToSCCCache{
 		mockCache: map[string]sets.String{
-			"controlled-namespace/testspecificsa":                          sets.NewString("scc_restricted", "scc_baseline"),
-			"controlled-namespace/testspecificsa2":                         sets.NewString("scc_restricted", "scc_privileged"),
-			"controlled-namespace/testspecificsa3":                         sets.NewString("scc_restricted"),
-			"controlled-namespace-previous-enforce-labels/testspecificsa3": sets.NewString("scc_restricted"),
-			"controlled-namespace-previous-warn-labels/testspecificsa3":    sets.NewString("scc_restricted"),
+			"controlled-namespace/testspecificsa":  sets.NewString("scc_restricted", "scc_baseline"),
+			"controlled-namespace/testspecificsa2": sets.NewString("scc_restricted", "scc_privileged"),
+			"controlled-namespace/testspecificsa3": sets.NewString("scc_restricted"),
 		},
 	}
 
@@ -360,26 +356,6 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 			expectNSUpdate:   true,
 			expectedPSaLevel: "restricted",
 		},
-		{
-			name:   "SA with restricted SCC assigned in an NS with previous enforce labels",
-			nsName: "controlled-namespace-previous-enforce-labels",
-			serviceAccounts: []*corev1.ServiceAccount{
-				{ObjectMeta: metav1.ObjectMeta{Name: "testspecificsa3", Namespace: "controlled-namespace-previous-enforce-labels"}},
-			},
-			wantErr:          false,
-			expectNSUpdate:   true,
-			expectedPSaLevel: "restricted",
-		},
-		{
-			name:   "SA with restricted SCC assigned in an NS with previous warn labels",
-			nsName: "controlled-namespace-previous-warn-labels",
-			serviceAccounts: []*corev1.ServiceAccount{
-				{ObjectMeta: metav1.ObjectMeta{Name: "testspecificsa3", Namespace: "controlled-namespace-previous-warn-labels"}},
-			},
-			wantErr:          false,
-			expectNSUpdate:   true,
-			expectedPSaLevel: "restricted",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -442,9 +418,8 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 			require.Equal(t, tt.expectNSUpdate, (nsModified != nil), "expected NS update to be %v, but it was %v", tt.expectNSUpdate, nsModified)
 
 			if nsModified != nil && len(tt.expectedPSaLevel) > 0 {
-				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.EnforceLevelLabel], "unexpected PSa enforcement level")
-				require.Equal(t, "", nsModified.Labels[psapi.WarnLevelLabel], "unexpected PSa warn level")
-				require.Equal(t, "", nsModified.Labels[psapi.AuditLevelLabel], "unexpected PSa audit level")
+				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.WarnLevelLabel], "unexpected PSa warn level")
+				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.AuditLevelLabel], "unexpected PSa audit level")
 			}
 		})
 	}


### PR DESCRIPTION
built on top of a simple revert to make it easier to merge.  This allows the featuregate defined in https://github.com/openshift/api/pull/1341 to control whether the auto-labeler is enabled when the controller sets the featuregates in https://github.com/openshift/cluster-kube-controller-manager-operator/pull/663