### PR TITLE
bump PSa version to k8s.io

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -33,7 +33,7 @@ import (
 const (
 	controllerName        = "pod-security-admission-label-synchronization-controller"
 	labelSyncControlLabel = "security.openshift.io/scc.podSecurityLabelSync"
-	currentPSaVersion     = "v1.24"
+	currentPSaVersion     = "v1.25"
 )
 
 // PodSecurityAdmissionLabelSynchronizationController watches over namespaces labelled with


### PR DESCRIPTION
# What

We would like to bump PSa version to 1.25.

# Why

k8s.io has a new version and we should not fall behind.

# Notes

I started a discussion in k8s Slack wrt a better overview: [link](https://kubernetes.slack.com/archives/C0EN96KUY/p1671466457960329).
I started a discussion in Red Hat Slack: [link](https://coreos.slack.com/archives/CC3CZCQHM/p1671467500970319).

Change made upstream:

> Privilege Escalation (v1.8+) | Privilege escalation (such as via set-user-ID or set-group-ID file mode) should not be allowed. This is Linux only policy in v1.25+ (spec.os.name != windows)
>
> https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted


Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>