### PR TITLE
OCPBUGS-8271: external template and route Informer

### DIFF
--- a/pkg/client/genericinformers/interface.go
+++ b/pkg/client/genericinformers/interface.go
@@ -3,7 +3,6 @@ package genericinformers
 import (
 	"k8s.io/klog/v2"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 )
@@ -12,19 +11,6 @@ type GenericResourceInformer interface {
 	ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error)
 	Start(stopCh <-chan struct{})
 }
-
-// GenericInternalResourceInformerFunc will return an internal informer for any resource matching
-// its group resource, instead of the external version. Only valid for use where the type is accessed
-// via generic interfaces, such as the garbage collector with ObjectMeta.
-type GenericInternalResourceInformerFunc func(resource schema.GroupVersionResource) (informers.GenericInformer, error)
-
-func (fn GenericInternalResourceInformerFunc) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
-	resource.Version = runtime.APIVersionInternal
-	return fn(resource)
-}
-
-// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
-func (fn GenericInternalResourceInformerFunc) Start(stopCh <-chan struct{}) {}
 
 // genericResourceInformerFunc will handle a cast to a matching type
 type GenericResourceInformerFunc func(resource schema.GroupVersionResource) (informers.GenericInformer, error)

--- a/pkg/cmd/controller/interfaces.go
+++ b/pkg/cmd/controller/interfaces.go
@@ -141,13 +141,13 @@ func (c *EnhancedControllerContext) ToGenericInformer() genericinformers.Generic
 		genericinformers.GenericResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
 			return c.ImageInformers.ForResource(resource)
 		}),
-		genericinformers.GenericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+		genericinformers.GenericResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
 			return c.QuotaInformers.ForResource(resource)
 		}),
 		genericinformers.GenericResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
 			return c.RouteInformers.ForResource(resource)
 		}),
-		genericinformers.GenericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+		genericinformers.GenericResourceInformerFunc(func(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
 			return c.TemplateInformers.ForResource(resource)
 		}),
 	)


### PR DESCRIPTION
1. external template and route Informer, I think this is caused by commit  https://github.com/openshift/cluster-policy-controller/commit/ccd7b3e29db2c01a73dd42c14096b823ad4d8072 and some other similar commit

2. log and analysis show in this issue:
[# issue 99  cluster-policy-controller log err](https://github.com/openshift/cluster-policy-controller/issues/99)