### PR TITLE
update controller-manager dependency to point to v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/apiserver v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/component-base v0.25.0
-	k8s.io/controller-manager v0.0.0
+	k8s.io/controller-manager v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/kubernetes v1.25.0
 	k8s.io/pod-security-admission v0.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1157,7 +1157,7 @@ k8s.io/component-helpers/auth/rbac/validation
 k8s.io/component-helpers/scheduling/corev1
 k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/volume
-# k8s.io/controller-manager v0.0.0 => k8s.io/controller-manager v0.25.0
+# k8s.io/controller-manager v0.25.0 => k8s.io/controller-manager v0.25.0
 ## explicit; go 1.19
 k8s.io/controller-manager/app
 k8s.io/controller-manager/pkg/clientbuilder


### PR DESCRIPTION
It seems art is having issues building olm images due to v0.0.0 of the controller-manager dependency. This PR just points the dependency to v0.25.0