### PR TITLE
OCPBUGS-7705: [release-4.12] update dependencies to point to v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/controller-manager v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/kubernetes v1.25.0
-	k8s.io/pod-security-admission v0.0.0
+	k8s.io/pod-security-admission v0.25.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/apiserver v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/component-base v0.25.0
-	k8s.io/controller-manager v0.0.0
+	k8s.io/controller-manager v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/kubernetes v1.25.0
 	k8s.io/pod-security-admission v0.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1157,7 +1157,7 @@ k8s.io/component-helpers/auth/rbac/validation
 k8s.io/component-helpers/scheduling/corev1
 k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/volume
-# k8s.io/controller-manager v0.0.0 => k8s.io/controller-manager v0.25.0
+# k8s.io/controller-manager v0.25.0 => k8s.io/controller-manager v0.25.0
 ## explicit; go 1.19
 k8s.io/controller-manager/app
 k8s.io/controller-manager/pkg/clientbuilder

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1220,7 +1220,7 @@ k8s.io/kubernetes/pkg/util/hash
 k8s.io/kubernetes/pkg/util/parsers
 k8s.io/kubernetes/pkg/util/taints
 k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac
-# k8s.io/pod-security-admission v0.0.0 => k8s.io/pod-security-admission v0.25.0
+# k8s.io/pod-security-admission v0.25.0 => k8s.io/pod-security-admission v0.25.0
 ## explicit; go 1.19
 k8s.io/pod-security-admission/api
 # k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed


### PR DESCRIPTION
This is a backport of https://github.com/openshift/cluster-policy-controller/pull/101 and https://github.com/openshift/cluster-policy-controller/pull/103 - it seems the operator-manager dependency is breaking ART