### PR TITLE
update psa dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/controller-manager v0.25.0
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/kubernetes v1.25.0
-	k8s.io/pod-security-admission v0.0.0
+	k8s.io/pod-security-admission v0.25.0
 )
 
 require (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1220,7 +1220,7 @@ k8s.io/kubernetes/pkg/util/hash
 k8s.io/kubernetes/pkg/util/parsers
 k8s.io/kubernetes/pkg/util/taints
 k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac
-# k8s.io/pod-security-admission v0.0.0 => k8s.io/pod-security-admission v0.25.0
+# k8s.io/pod-security-admission v0.25.0 => k8s.io/pod-security-admission v0.25.0
 ## explicit; go 1.19
 k8s.io/pod-security-admission/api
 # k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed


### PR DESCRIPTION
ART seems to be having trouble building olm images because of v0.0.0 dependencies here. Seems to be a bug in cachito.