### PR TITLE
psalabelsyncer: synchronize also audit and warn labels when enforcing

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -255,29 +255,19 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) syncNamespace(ctx c
 	var changed bool
 
 	if c.shouldEnforce {
-		if nsCopy.Labels[psapi.EnforceLevelLabel] != string(psaLevel) || nsCopy.Labels[psapi.EnforceVersionLabel] != currentPSaVersion {
-			changed = true
-			if nsCopy.Labels == nil {
-				nsCopy.Labels = map[string]string{}
-			}
-
-			nsCopy.Labels[psapi.EnforceLevelLabel] = string(psaLevel)
-			nsCopy.Labels[psapi.EnforceVersionLabel] = currentPSaVersion
-		}
-
-		// cleanup audit and warn labels from version 4.11
-		// TODO: This can be removed in 4.13 and allow users set these as they wish
 		for typeLabel, versionLabel := range map[string]string{
-			psapi.WarnLevelLabel:  psapi.WarnVersionLabel,
-			psapi.AuditLevelLabel: psapi.AuditVersionLabel,
+			psapi.EnforceLevelLabel: psapi.EnforceVersionLabel,
+			psapi.WarnLevelLabel:    psapi.WarnVersionLabel,
+			psapi.AuditLevelLabel:   psapi.AuditVersionLabel,
 		} {
-			if _, ok := nsCopy.Labels[typeLabel]; ok {
-				delete(nsCopy.Labels, typeLabel)
+			if nsCopy.Labels[typeLabel] != string(psaLevel) || nsCopy.Labels[versionLabel] != currentPSaVersion {
 				changed = true
-			}
-			if _, ok := nsCopy.Labels[versionLabel]; ok {
-				delete(nsCopy.Labels, versionLabel)
-				changed = true
+				if nsCopy.Labels == nil {
+					nsCopy.Labels = map[string]string{}
+				}
+
+				nsCopy.Labels[typeLabel] = string(psaLevel)
+				nsCopy.Labels[versionLabel] = currentPSaVersion
 			}
 		}
 	} else {

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
@@ -444,8 +444,8 @@ func TestEnforcingPodSecurityAdmissionLabelSynchronizationController_sync(t *tes
 
 			if nsModified != nil && len(tt.expectedPSaLevel) > 0 {
 				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.EnforceLevelLabel], "unexpected PSa enforcement level")
-				require.Equal(t, "", nsModified.Labels[psapi.WarnLevelLabel], "unexpected PSa warn level")
-				require.Equal(t, "", nsModified.Labels[psapi.AuditLevelLabel], "unexpected PSa audit level")
+				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.WarnLevelLabel], "unexpected PSa warn level")
+				require.Equal(t, tt.expectedPSaLevel, nsModified.Labels[psapi.AuditLevelLabel], "unexpected PSa audit level")
 			}
 		})
 	}


### PR DESCRIPTION
Currently the EnforcingPodSecurityAdmissionLabelSynchronizationController is setting only the `pod-security.kubernetes.io/enforce` label ignoring `pod-security.kubernetes.io/warn` and `pod-security.kubernetes.io/audit` ones (it's eventually simply removing leftovers from 4.11). This means that we can end in situations where the POD is actually admitted at `privileged` level altough it's still audited and it will still cause a user user-facing warning.

Let's sync also `pod-security.kubernetes.io/audit` and `pod-security.kubernetes.io/warn` at the same level when setting `pod-security.kubernetes.io/enforce` to get a consistent behaviour.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2223948