### PR TITLE
OCPBUGS-15568: Add timeout into cache sync wait to prevent hanging forever

### DIFF
--- a/pkg/quota/clusterquotareconciliation/reconciliation_controller.go
+++ b/pkg/quota/clusterquotareconciliation/reconciliation_controller.go
@@ -201,9 +201,7 @@ func (c *ClusterQuotaReconcilationController) Sync(discoveryFunc resourcequota.N
 			return
 		}
 
-		// Something has changed, so track the new state and perform a sync.
-		klog.V(2).Infof("syncing resource quota controller with updated resources from discovery: %v", newResources)
-		oldResources = newResources
+		klog.V(2).Infof("syncing resource quota controller with updated resources from discovery: %s", printDiff(oldResources, newResources))
 
 		// Ensure workers are paused to avoid processing events before informers
 		// have resynced.
@@ -215,11 +213,43 @@ func (c *ClusterQuotaReconcilationController) Sync(discoveryFunc resourcequota.N
 			utilruntime.HandleError(fmt.Errorf("failed to sync resource monitors: %v", err))
 			return
 		}
-		if c.quotaMonitor != nil && !cache.WaitForCacheSync(ctx.Done(), func() bool { return c.quotaMonitor.IsSynced(context.TODO()) }) {
+		if c.quotaMonitor != nil && !cache.WaitForCacheSync(waitForStopOrTimeout(ctx.Done(), period), func() bool { return c.quotaMonitor.IsSynced(context.TODO()) }) {
 			utilruntime.HandleError(fmt.Errorf("timed out waiting for quota monitor sync"))
 		}
+
+		oldResources = newResources
 		klog.V(2).Infof("synced cluster resource quota controller")
 	}, period, ctx.Done())
+}
+
+// printDiff returns a human-readable summary of what resources were added and removed
+func printDiff(oldResources, newResources map[schema.GroupVersionResource]struct{}) string {
+	removed := sets.NewString()
+	for oldResource := range oldResources {
+		if _, ok := newResources[oldResource]; !ok {
+			removed.Insert(fmt.Sprintf("%+v", oldResource))
+		}
+	}
+	added := sets.NewString()
+	for newResource := range newResources {
+		if _, ok := oldResources[newResource]; !ok {
+			added.Insert(fmt.Sprintf("%+v", newResource))
+		}
+	}
+	return fmt.Sprintf("added: %v, removed: %v", added.List(), removed.List())
+}
+
+// waitForStopOrTimeout returns a stop channel that closes when the provided stop channel closes or when the specified timeout is reached
+func waitForStopOrTimeout(stopCh <-chan struct{}, timeout time.Duration) <-chan struct{} {
+	stopChWithTimeout := make(chan struct{})
+	go func() {
+		defer close(stopChWithTimeout)
+		select {
+		case <-stopCh:
+		case <-time.After(timeout):
+		}
+	}()
+	return stopChWithTimeout
 }
 
 // resyncMonitors starts or stops quota monitors as needed to ensure that all


### PR DESCRIPTION
Previously, cluster quota reconciliation used small subset of informers and that worked without any 
problem with the one important downside that only these small subset of resources were supported
by `clusterresourcequota` unlike to the builtin `resourcequota`.

After https://github.com/openshift/cluster-policy-controller/pull/115, cluster quota started using 
genericinformers(more specifically metadatainformers) rather than pre-defined static resource based informers to  support all other resources including CRDs.

But that brings about hanging problem as defined;

* cluster quota monitor acquires lock to start informers for all the newly created resources
* workers in https://github.com/openshift/cluster-policy-controller/blob/2a9b7b4daa7f4b7a5a0a3536426371a78390ed16/pkg/quota/clusterquotareconciliation/reconciliation_controller.go#L298 wait the workerlock being released by quota monitor
* however, due to this https://github.com/kubernetes/kubernetes/issues/71450 issue, quota monitor hangs "forever"
* which leads that controllers in quota reconciliation are locked "forever".

This was fixed in upstream with this commit https://github.com/kubernetes/kubernetes/pull/74747/commits/739df5452a407636a927ac75395784d5bcca9460(and this https://github.com/kubernetes/kubernetes/pull/74747/commits/e5f7af70583b758978c819cd5c0c6a3ddb6fee28) and this PR takes this commit's relevant bits in cluster-policy-controller.

**How we noticed that behavior?**

Our CI test `Cluster resource quota should control resource limits across namespaces` started failing sporadically because quota reconciliation started listening all the resources including the test CRDs created by other tests which resulted in these test CRDs causing creation of informers in quota controller.

