### PR TITLE
OCPBUGS-17458: ps syncer: don't hotloop on a missing namespace

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -194,6 +194,10 @@ func (c *PodSecurityAdmissionLabelSynchronizationController) sync(ctx context.Co
 	qKey := controllerContext.QueueKey()
 	ns, err := c.namespaceLister.Get(qKey)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("namespace %q was not found, nothing to do", qKey)
+			return nil
+		}
 		return fmt.Errorf(errFmt, qKey, err)
 	}
 

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
@@ -422,9 +422,8 @@ func TestEnforcingPodSecurityAdmissionLabelSynchronizationController_sync(t *tes
 		expectedPSaVersion string
 	}{
 		{
-			name:    "non-existent ns",
-			nsName:  "unknown",
-			wantErr: true,
+			name:   "non-existent ns",
+			nsName: "unknown",
 		},
 		{
 			name:   "terminating ns",
@@ -652,9 +651,8 @@ func TestPodSecurityAdmissionLabelSynchronizationController_sync(t *testing.T) {
 		expectedPSaLevel string
 	}{
 		{
-			name:    "non-existent ns",
-			nsName:  "unknown",
-			wantErr: true,
+			name:   "non-existent ns",
+			nsName: "unknown",
 		},
 		{
 			name:   "terminating ns",


### PR DESCRIPTION
If a namespace is removed between queue add and the Get(), a non-nil error would cause the namespace would be added back to the queue, looping forever.

/cc @openshift/openshift-team-auth 