### PR TITLE
AUTH-537: pkg/psalabelsyncer: switch to PSA version 'latest'

### DIFF
--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller.go
@@ -36,7 +36,7 @@ import (
 const (
 	controllerName        = "pod-security-admission-label-synchronization-controller"
 	labelSyncControlLabel = "security.openshift.io/scc.podSecurityLabelSync"
-	currentPSaVersion     = "v1.24"
+	currentPSaVersion     = "latest"
 )
 
 var (

--- a/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
+++ b/pkg/psalabelsyncer/podsecurity_label_sync_controller_test.go
@@ -508,7 +508,7 @@ func TestEnforcingPodSecurityAdmissionLabelSynchronizationController_sync(t *tes
 			wantErr:            false,
 			expectNSUpdate:     true,
 			expectedPSaLevel:   "restricted",
-			expectedPSaVersion: "v1.24",
+			expectedPSaVersion: "latest",
 		},
 		{
 			name:           "SA with restricted SCC, NS with previous enforce version managed by someone else but sync label set to false",


### PR DESCRIPTION
# What

Switching the label from `v1.24` to `latest`.

# Why

We are making this change for two main reasons:

1. To avoid using an outdated version label.
2. To reduce maintenance overhead.

By using the `latest` tag, we ensure that our references always point to the most recent version without requiring manual updates.