### PR TITLE
OCPBUGS-43380: psalabelsyncer: add image volume type to list

### DIFF
--- a/pkg/psalabelsyncer/scctopsamapping.go
+++ b/pkg/psalabelsyncer/scctopsamapping.go
@@ -287,6 +287,7 @@ func convert_volumes(volumes []securityv1.FSType) uint8 {
 	//     csi
 	//     persistentVolumeClaim
 	//     ephemeral
+	//     image
 	// ------------------------------------
 	// upstream: check_hostPathVolumes
 	// baseline allows: undefined/null
@@ -305,7 +306,8 @@ func convert_volumes(volumes []securityv1.FSType) uint8 {
 			securityv1.FSTypeCSI,
 			securityv1.FSTypePersistentVolumeClaim,
 			securityv1.FSTypeEphemeral,
-			securityv1.FSTypeNone:
+			securityv1.FSTypeNone,
+			securityv1.FSTypeImage:
 			if currentLevel < restricted {
 				currentLevel = restricted
 			}


### PR DESCRIPTION
We're seeing this panic in some jobs, because we're missing the new [image volume type](https://kubernetes.io/blog/2024/08/16/kubernetes-1-31-image-volume-source/):

Example: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/4847/pull-ci-openshift-hypershift-main-e2e-kubevirt-aws-ovn/1843256448415436800